### PR TITLE
update gleam to v0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "cgl"
 license = "MIT / Apache-2.0"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The Servo Project Developers"]
 description = "Rust bindings for CGL on Mac"
 repository = "https://github.com/servo/cgl-rs"
 
 [dependencies]
 libc = "0.2"
-gleam = "0.3"
+gleam = "0.4"


### PR DESCRIPTION
Fixes  #23.

cgl's version update is minor since, gleam's update affect only to direct caller of GlesFns::load_with() and GlesFns::load_with().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/cgl-rs/24)
<!-- Reviewable:end -->
