### PR TITLE
Remove gleam dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "cgl"
 license = "MIT / Apache-2.0"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["The Servo Project Developers"]
 description = "Rust bindings for CGL on Mac"
 repository = "https://github.com/servo/cgl-rs"
 
 [dependencies]
 libc = "0.2"
-gleam = "0.7"

--- a/src/cgl.rs
+++ b/src/cgl.rs
@@ -11,8 +11,13 @@
 
 #![allow(non_upper_case_globals)]
 
-use gleam::gl::{GLenum, GLint, GLsizei, GLuint};
 use libc::{c_void, c_int, c_char};
+use std::os::raw;
+
+pub type GLenum = raw::c_uint;
+pub type GLint = raw::c_int;
+pub type GLsizei = raw::c_int;
+pub type GLuint = raw::c_uint;
 
 pub type CGLPixelFormatAttribute = c_int;
 pub type CGLContextParameter = c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@
 #![crate_type = "lib"]
 
 extern crate libc;
-extern crate gleam;
 
 pub use cgl::*;
 


### PR DESCRIPTION
This will make future breaking changes to gleam slightly easier because we won't have to update glutin, which depends on cgl.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/cgl-rs/29)
<!-- Reviewable:end -->
